### PR TITLE
Detect the executable from $PATH

### DIFF
--- a/rplugin/python3/denite/filter/matcher_fzf.py
+++ b/rplugin/python3/denite/filter/matcher_fzf.py
@@ -31,10 +31,6 @@ class Filter(Base):
             # fzf installation check
             ext = '.exe' if context['is_windows'] else ''
             if globruntime(context['runtimepath'], 'bin/fzf' + ext):
-                # Add path
-                sys.path.append(os.path.dirname(
-                    globruntime(context['runtimepath'],
-                                'bin/fzf' + ext)[0]))
                 self.__initialized = True
             else:
                 error(self.vim, 'matcher_fzf: bin/fzf' + ext +

--- a/rplugin/python3/denite/filter/matcher_fzf.py
+++ b/rplugin/python3/denite/filter/matcher_fzf.py
@@ -9,6 +9,7 @@ from denite.util import globruntime, error, convert2fuzzy_pattern
 import sys
 import os
 from subprocess import Popen, PIPE
+from shutil import which
 
 
 class Filter(Base):
@@ -30,7 +31,7 @@ class Filter(Base):
         if not self.__initialized:
             # fzf installation check
             ext = '.exe' if context['is_windows'] else ''
-            if globruntime(context['runtimepath'], 'bin/fzf' + ext):
+            if which('fzf') or globruntime(context['runtimepath'], 'bin/fzf' + ext):
                 self.__initialized = True
             else:
                 error(self.vim, 'matcher_fzf: bin/fzf' + ext +


### PR DESCRIPTION
This enables to detect the `fzf` executable from the `$PATH` env for people who have installed the binary itself.